### PR TITLE
metainfo: add brand colors

### DIFF
--- a/data/com.github.huluti.Coulr.appdata.xml.in
+++ b/data/com.github.huluti.Coulr.appdata.xml.in
@@ -30,6 +30,11 @@
     </screenshot>
   </screenshots>
 
+  <branding>
+    <color type="primary" scheme_preference="light">#57e389</color>
+    <color type="primary" scheme_preference="dark">#1c7a4f</color>
+  </branding>
+
   <translation type="gettext">coulr</translation>
   <launchable type="desktop-id">com.github.huluti.Coulr.desktop</launchable>
 


### PR DESCRIPTION
Context: https://docs.flathub.org/blog/quality-moderation

![image](https://github.com/Huluti/Coulr/assets/1908896/1b1d7e3f-ea89-4096-bdf1-3ae0b1c15b43)
