### PR TITLE
desktop: Add keywords

### DIFF
--- a/data/com.github.huluti.Coulr.desktop.in
+++ b/data/com.github.huluti.Coulr.desktop.in
@@ -5,6 +5,8 @@ Comment=Color box to help developers and designers
 Terminal=false
 Type=Application
 Categories=GNOME;GTK;Graphics;
+# These are search terms to find this application. Do not translate or localize the semicolons. The list must also end with a semicolon.
+Keywords=colour;color;picker; 
 # Icon name, do not translate
 Icon=com.github.huluti.Coulr
 StartupWMClass=coulr


### PR DESCRIPTION
Sometimes it can be difficult to remember the app name, and this should make easier to find the app